### PR TITLE
Wrapper for `hadron` library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "latqcdtools/pyhadron"]
+	path = latqcdtools/pyhadron
+	url = https://github.com/simone-romiti/pyhadron


### PR DESCRIPTION
I've simply added [pyhadron](https://github.com/simone-romiti/pyhadron) as git submodule in the `latqcdtools` folder.
It is a python wrapper for the `R` library [`hadron`](https://github.com/HISKP-LQCD/hadron) based on the `rpy2` library.

To do: 

- [ ] add the documentation here on how to use it
- [ ] show some examples (e.g. [`uwerr` analysis](https://arxiv.org/abs/hep-lat/0306017))
- [ ] integrate with the other tools already available in this Toolbox