### PR TITLE
Default value of nproc in fitting.py

### DIFF
--- a/latqcdtools/statistics/fitting.py
+++ b/latqcdtools/statistics/fitting.py
@@ -112,7 +112,7 @@ class Fitter:
         self._args          = kwargs.get('args', ())
         self._grad_args     = kwargs.get('grad_args', None)
         self._errorAlg      = kwargs.get('error_strat', 'propagation')
-        self._nproc         = kwargs.get('nproc', DEFAULTTHREADS)
+        self._nproc         = kwargs.get('nproc', 1)
         logger.debug('Initialize fitter with:')
         logger.debug('  use_diff:',self._use_diff) 
         logger.debug('  derive_chisq:',self._derive_chisq)


### PR DESCRIPTION
I measured the time of the fitting class for different numbers of nproc. In my case nproc = 1 i.e. a normal for loop was the fastest and an other values makes the code slower.